### PR TITLE
Remove dist folder from CodeClimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,2 @@
 languages:
    JavaScript: true
-
-exclude_paths:
-  - "dist/js/*"


### PR DESCRIPTION
There is no need to exclude the dist folder as it no longer exists in the repository.